### PR TITLE
Allow an AWS region to be passed into the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ const athenaExpressConfig = {
 	getStats: BOOLEAN, /* optional default=false */
 	ignoreEmpty: BOOLEAN, /* optional default=true */
 	encryption: OBJECT /* optional */
-    skipResults: BOOLEAN /* optional default=false */
+	skipResults: BOOLEAN /* optional default=false */
+	region: "STRING_VALUE", /* optional default=aws.config.region */
 };
 
 //Initializing AthenaExpress
@@ -146,6 +147,7 @@ const athenaExpress = new AthenaExpress(athenaExpressConfig);
 |ignoreEmpty  | boolean | `true`| Ignore fields with empty values from the final JSON response.  |
 |encryption | object | -- | [Encryption configuation](https://docs.aws.amazon.com/athena/latest/ug/encryption.html) example usage: <br />`{ EncryptionOption: "SSE_KMS", KmsKey: process.env.kmskey}` |
 |skipResults | boolean | `false` | For a unique requirement where a user may only want to execute the query in Athena and store the results in S3 but NOT fetch those results in that moment. <br />Perhaps to be retrieved later or simply stored in S3 for auditing/logging purposes. <br />Best used with a combination of `getStats : true` so that the `QueryExecutionId` & `S3Location` can be captured for later reference.   |
+| region | string  | `aws.config.region`  | AWS region for S3 and Athena  |
 
 ## Usage: Invoking athena-express
 

--- a/lib/athenaExpress.js
+++ b/lib/athenaExpress.js
@@ -11,8 +11,8 @@ module.exports = class AthenaExpress {
 	constructor(init) {
 		validateConstructor(init);
 		this.config = {
-			athena: new init.aws.Athena({ apiVersion: "2017-05-18" }),
-			s3: new init.aws.S3({ apiVersion: "2006-03-01" }),
+			athena: new init.aws.Athena({ apiVersion: "2017-05-18", region: init.region, }),
+			s3: new init.aws.S3({ apiVersion: "2006-03-01", region: init.region, }),
 			s3Bucket:
 				init.s3 ||
 				`s3://athena-express-${init.aws.config.credentials.accessKeyId
@@ -230,7 +230,7 @@ function validateConstructor(init) {
 
 	try {
 		let aws = init.s3 ? init.s3 : init.aws.config.credentials.accessKeyId;
-		let athena = new init.aws.Athena({ apiVersion: "2017-05-18" });
+		let athena = new init.aws.Athena({ apiVersion: "2017-05-18", region: init.region, });
 	} catch (e) {
 		throw new TypeError(
 			"AWS object not present or incorrect in the constructor"


### PR DESCRIPTION
I ran into a problem where I was trying to make Athena queries against two AWS regions simultaneously. I was using `aws.config.update` to set my region each time, but that's a global config that would change in-between the Athena and S3 calls in `athena-express`. 

To solve, I've added a new config parameter `region` that can be passed into the constructor. If it's not passed, the default behaviour will set the region.