### PR TITLE
Build Fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,10 +40,9 @@ declare module 'athena-express' {
     type QueryResult<T> = OptionalQueryResultsInterface<T>;
     type QueryFunc<T> = (query: QueryObjectInterface|DirectQueryString|QueryExecutionId) => Promise<QueryResult<T>>;
 
-    class AthenaExpress {
+    class AthenaExpress<T> {
         public new: (config: Partial<ConnectionConfigInterface>) => any;
-        public query: QueryFunc;
+        public query: QueryFunc<T>;
         constructor(config: Partial<ConnectionConfigInterface>);
-        query: QueryFunc;
     }
 }


### PR DESCRIPTION
Fixes type errors in index.d.ts
Generic type 'QueryFunc' requires 1 type argument(s).ts(2314) [46,23]
Duplicate identifier 'query'.ts(2300) [48,9]
Generic type 'QueryFunc' requires 1 type argument(s).ts(2314) [48,16]

This might not be the best fix and I am open to alternative fixes to these errors, but I thought you might want to know the issues I am running into.