### PR TITLE
Fixed logic on addDataType function to set non-string values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,7 @@ typings/
 # dotenv environment variables file
 .env
 
-example.js
+# vscode launch configuration
+.vscode
 
+example.js

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,6 +5,49 @@ const readline = require("readline"),
 
 let s3Metadata = null;
 
+let unflatten = function(data) {
+    "use strict";
+    if (Object(data) !== data || Array.isArray(data))
+        return data;
+    var regex = /\.?([^.\[\]]+)|\[(\d+)\]/g,
+        resultholder = {};
+    for (var p in data) {
+        var cur = resultholder,
+            prop = "",
+            m;
+        while (m = regex.exec(p)) {
+            cur = cur[prop] || (cur[prop] = (m[2] ? [] : {}));
+            prop = m[2] || m[1];
+        }
+        cur[prop] = data[p];
+    }
+    return resultholder[""] || resultholder;
+};
+
+let flatten = function(data) {
+    var result = {};
+    function recurse (cur, prop) {
+        if (Object(cur) !== cur) {
+            result[prop] = cur;
+        } else if (Array.isArray(cur)) {
+             for(var i=0, l=cur.length; i<l; i++)
+                 recurse(cur[i], prop + "[" + i + "]");
+            if (l == 0)
+                result[prop] = [];
+        } else {
+            var isEmpty = true;
+            for (var p in cur) {
+                isEmpty = false;
+                recurse(cur[p], prop ? prop+"."+p : p);
+            }
+            if (isEmpty && prop)
+                result[prop] = {};
+        }
+    }
+    recurse(data, "");
+    return result;
+}
+
 function startQueryExecution(query, config) {
     const QueryString = query.sql || query;
 
@@ -152,16 +195,18 @@ async function cleanUpDML(input, ignoreEmpty) {
 
 function addDataType(input, dataTypes) {
     let updatedObjectWithDataType = {};
-
-    for (const key in input) {
+    const flat = flatten(input)
+    for (const key in flat) {
         switch (dataTypes[key]) {
             case "varchar":
-                updatedObjectWithDataType[key] = input[key];
+                updatedObjectWithDataType[key] = flat[key];
                 break;
             case "boolean":
-                updatedObjectWithDataType[key] = JSON.parse(
-                    input[key].toLowerCase()
-                );
+                if (flat[key]) {
+                    updatedObjectWithDataType[key] = JSON.parse(
+                        flat[key].toLowerCase()
+                    );
+                }
                 break;
             case "integer":
             case "tinyint":
@@ -169,13 +214,14 @@ function addDataType(input, dataTypes) {
             case "int":
             case "float":
             case "double":
-                updatedObjectWithDataType[key] = Number(input[key]);
+                updatedObjectWithDataType[key] = Number(flat[key]);
                 break;
             default:
-                updatedObjectWithDataType[key] = input[key];
+                updatedObjectWithDataType[key] = flat[key];
         }
     }
-    return updatedObjectWithDataType;
+    const result = unflatten(updatedObjectWithDataType)
+    return result;
 }
 
 function cleanUpNonDML(input) {


### PR DESCRIPTION
I have a query that results nested objects, e.g.
`SELECT id, item.id, item.label, item.price, order.quantity, order.subtotal  FROM orders`

The current behaviour resulting data from the Items collection is:
`
[{
  id: "O-100",
  item: {
    id: "item-12345",
    label: "Printer",
    price: "123.99"
  },
  order: {
    quantity: "1",
    subtotal: "123.99"
    qualifies_for_discount: "true"
  },
}]
`

I need the resulting nested objects non-string properties in the Items collection to be set as non-string, i.e. not in quotes.
Expected result:
`
[{
  id: "O-100",
  item: {
    id: "item-12345",
    label: "Printer",
    price: 123.99
  },
  order: {
    quantity: 1,
    subtotal: 123.99
    qualifies_for_discount: true
  },
}]
`
To accomplish this, it seems the record data has to be converted into a flat object map the loop in the addDataType function can iterate through all properties including those in the nested objects.