### PR TITLE
chore(package-lock): sync version with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "athena-express",
-  "version": "7.0.1",
+  "version": "7.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
It looks like this got missed in https://github.com/ghdna/athena-express/commit/7bd6429948508727e1128f18e6cad75a3e1d16dc#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519.