### PR TITLE
Fixed type validation with support for NULL

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -209,25 +209,29 @@ function addDataType(input, dataTypes) {
     let updatedObjectWithDataType = {};
 
     for (const key in input) {
-        switch (dataTypes[key]) {
-            case "varchar":
-                updatedObjectWithDataType[key] = input[key];
-                break;
-            case "boolean":
-                updatedObjectWithDataType[key] = JSON.parse(
-                    input[key].toLowerCase()
-                );
-                break;
-            case "integer":
-            case "tinyint":
-            case "smallint":
-            case "int":
-            case "float":
-            case "double":
-                updatedObjectWithDataType[key] = Number(input[key]);
-                break;
-            default:
-                updatedObjectWithDataType[key] = input[key];
+        if (!input[key]) {
+            updatedObjectWithDataType[key] = null;
+        } else {
+            switch (dataTypes[key]) {
+                case "varchar":
+                    updatedObjectWithDataType[key] = input[key];
+                    break;
+                case "boolean":
+                    updatedObjectWithDataType[key] = JSON.parse(
+                        input[key].toLowerCase()
+                    );
+                    break;
+                case "integer":
+                case "tinyint":
+                case "smallint":
+                case "int":
+                case "float":
+                case "double":
+                    updatedObjectWithDataType[key] = Number(input[key]);
+                    break;
+                default:
+                    updatedObjectWithDataType[key] = input[key];
+            }
         }
     }
     return updatedObjectWithDataType;


### PR DESCRIPTION
Without this fix when reading a boolean column with a NULL value ("" in the input CSV) it would fail to parse as JSON and in numeric columns the NULL value would be coerced to a 0. Now when an empty string is detected it is correctly handled as a NULL value.