### PR TITLE
Result reuse feature addition

### DIFF
--- a/lib/athenaExpress.js
+++ b/lib/athenaExpress.js
@@ -29,6 +29,7 @@ module.exports = class AthenaExpress {
             workgroup: init.workgroup || "primary",
             retry: Number(init.retry) || 200,
             formatJson: init.formatJson !== false,
+            reuse: init.reuse !== false,
             getStats: init.getStats || init.skipResults,
             ignoreEmpty: init.ignoreEmpty !== false,
             skipResults: init.skipResults,
@@ -68,6 +69,9 @@ module.exports = class AthenaExpress {
             }
             if (loweredCaseKeys.hasOwnProperty("sql")) {
                 config.sql = loweredCaseKeys.sql;
+            }
+            if (loweredCaseKeys.hasOwnProperty("reuse")) {
+                config.reuse = loweredCaseKeys.reuse;
             }
             if (loweredCaseKeys.hasOwnProperty("queryexecutionid")) {
                 config.QueryExecutionId = loweredCaseKeys.queryexecutionid;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -192,9 +192,13 @@ async function cleanUpDML(input, ignoreEmpty) {
         ignoreEmpty,
       })
         .on("data", (data) => {
-          cleanJson.push(
-            addDataType(JSON.parse(data.toString("utf8")), dataTypes)
-          );
+          try {
+            cleanJson.push(
+              addDataType(JSON.parse(data.toString("utf8")), dataTypes)
+            );
+          } catch (err) {
+            console.error("Incorrect data type found", err);
+          }
         })
         .on("finish", function () {
           resolve(cleanJson);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,6 +17,12 @@ function startQueryExecution(config) {
       Database: config.db,
       Catalog: config.catalog,
     },
+    ResultReuseConfiguration: {
+      ResultReuseByAgeConfiguration: {
+        Enabled: config.reuse,
+        MaxAgeInMinutes: 10080,
+      },
+    },
   };
   if (config.encryption)
     params.ResultConfiguration.EncryptionConfiguration = config.encryption;


### PR DESCRIPTION
Having used this library a lot, I decided to create a PR regarding a feature and an issue that helped me most.

1. The feature I added is the built-in "Result Reuse" feature that Athena provides in the management console. By enabling "reuse" config I added, you can use previously cached result up to 7 days, which helps so much with execution times.
2. Second one is a bug I encountered: while library is gathering streamed data from Athena, if there are some weird characters in the data and somehow it leads to incorrect data types, then addDataType function hangs forever and not responding. By simply adding a try-catch block, it returns data as expected and makes the incorrect data null so that it can be handled in the app logic.